### PR TITLE
cleanup setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,7 @@ setuptools.setup(
     license="MIT",
     install_requires=[
         'numpy',
-        'astropy<=2.0.7;python_version<="2.7"',
-        'astropy;python_version>"2.7"',
+        'astropy',
         'scipy'
     ],
     classifiers=[


### PR DESCRIPTION
This works for me as expected:
```
$ /tmp/tess-point [master|✚ 1] $ pip2 install -e .
Obtaining file:///private/tmp/tess-point
Requirement already satisfied: numpy in /usr/local/lib/python2.7/site-packages (from tess-point==0.3.1) (1.11.3)
Collecting astropy (from tess-point==0.3.1)
  Using cached https://files.pythonhosted.org/packages/12/5e/33bd9fe91714357b8dd6825cd5f1668e887b72a9d94e39509bb733563c15/astropy-2.0.11-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
Requirement already satisfied: scipy in /usr/local/lib/python2.7/site-packages (from tess-point==0.3.1) (1.1.0)
Requirement already satisfied: pytest<3.7,>=2.8 in /usr/local/lib/python2.7/site-packages (from astropy->tess-point==0.3.1) (3.6.4)
Requirement already satisfied: atomicwrites>=1.0 in /usr/local/lib/python2.7/site-packages (from pytest<3.7,>=2.8->astropy->tess-point==0.3.1) (1.2.1)
Requirement already satisfied: pluggy<0.8,>=0.5 in /usr/local/lib/python2.7/site-packages (from pytest<3.7,>=2.8->astropy->tess-point==0.3.1) (0.7.1)
Requirement already satisfied: py>=1.5.0 in /usr/local/lib/python2.7/site-packages (from pytest<3.7,>=2.8->astropy->tess-point==0.3.1) (1.7.0)
Requirement already satisfied: setuptools in /usr/local/lib/python2.7/site-packages (from pytest<3.7,>=2.8->astropy->tess-point==0.3.1) (40.6.3)
Requirement already satisfied: six>=1.10.0 in /usr/local/lib/python2.7/site-packages (from pytest<3.7,>=2.8->astropy->tess-point==0.3.1) (1.12.0)
Requirement already satisfied: more-itertools>=4.0.0 in /usr/local/lib/python2.7/site-packages (from pytest<3.7,>=2.8->astropy->tess-point==0.3.1) (5.0.0)
Requirement already satisfied: attrs>=17.4.0 in /usr/local/lib/python2.7/site-packages (from pytest<3.7,>=2.8->astropy->tess-point==0.3.1) (18.2.0)
Requirement already satisfied: funcsigs; python_version < "3.0" in /usr/local/lib/python2.7/site-packages (from pytest<3.7,>=2.8->astropy->tess-point==0.3.1) (1.0.2)
Installing collected packages: astropy, tess-point
  Found existing installation: tess-point 0.3.1
    Uninstalling tess-point-0.3.1:
      Successfully uninstalled tess-point-0.3.1
  Running setup.py develop for tess-point
Successfully installed astropy-2.0.11 tess-point
```

The trick is you need a recent (~year old or so) setuptools, and pip. I have 40.6.3 and 18.0 of them locally,  but bit older ones should work, too (they need to understand the `python_requires` in astropy that limits the supported python versions. More info here: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires